### PR TITLE
call of overloaded 'abs(size_t)' is ambiguous fix added

### DIFF
--- a/mednafen.spec
+++ b/mednafen.spec
@@ -6,6 +6,7 @@ Summary:        A multi-system emulator utilizing OpenGL and SDL
 License:        GPLv2+ and BSD and ISC and LGPLv2+ and MIT and zlib 
 URL:            http://mednafen.sourceforge.net
 Source0:        http://mednafen.fobby.net/releases/files/mednafen-%{version}.tar.bz2
+Patch0:         patch_abs_fix.patch
 BuildRequires:  gettext
 BuildRequires:  pkgconfig >= 0.9.0
 BuildRequires:  SDL_net-devel >= 1.2.0
@@ -43,6 +44,7 @@ reasons.
 
 %prep
 %setup -q -n %{name}
+%patch -P0
 
 # Permission cleanups for debuginfo
 find \( -name \*.c\* -or -name \*.h\* \) -exec chmod -x {} \;

--- a/patch_abs_fix.patch
+++ b/patch_abs_fix.patch
@@ -1,0 +1,11 @@
+--- src/cdrom/CDAccess_CCD.cpp	2015-02-23 00:50:48.000000000 +0400
++++ src/cdrom/CDAccess_CCD.cpp	2016-07-01 14:28:09.020693594 +0400
+@@ -346,7 +346,7 @@
+      if(prev_lba != INT_MAX && abs(lba - prev_lba) > 100)
+       throw MDFN_Error(0, _("Garbage subchannel Q data detected(excessively large jump in AMSF)"));
+ 
+-     if(abs(lba - s) > 100)
++     if(abs((int)(lba - s)) > 100)
+       throw MDFN_Error(0, _("Garbage subchannel Q data detected(AMSF value is out of tolerance)"));
+ 
+      prev_lba = lba;


### PR DESCRIPTION
Fix error compiling with GCC 6.x on Fedora 24

http://forum.fobby.net/index.php?t=msg&goto=4390&
